### PR TITLE
$ONTEXT and $OFFTEXT are now case-insensitive

### DIFF
--- a/Gams.tmLanguage
+++ b/Gams.tmLanguage
@@ -72,11 +72,11 @@
 		<key>blockcomment</key>
 		<dict>
 			<key>begin</key>
-			<string>^\$ONTEXT</string>
+			<string>^\$[Oo][Nn][Tt][Ee][Xx][Tt]</string>
 			<key>contentName</key>
 			<string>comment.block.documentation.gms</string>
 			<key>end</key>
-			<string>^\$OFFTEXT</string>
+			<string>^\$[Oo][Ff][Ff][Tt][Ee][Xx][Tt]</string>
 			<key>name</key>
 			<string>keyword.control.gms</string>
 		</dict>


### PR DESCRIPTION
Hi, this fixes Issue #4 https://github.com/lolow/sublime-gams/issues/4.
$ONTEXT and $OFFTEXT are now case-insensitive
